### PR TITLE
Set `avoidEscape: true` for quotes rules

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,10 +21,22 @@ module.exports = {
     "plugin:@typescript-eslint/recommended",
   ],
   rules: {
-    "semi": ["error", "never"],
-    "quotes": ["error", "double"],
+    semi: ["error", "never"],
+    quotes: [
+      "error",
+      "double",
+      {
+        avoidEscape: true,
+      },
+    ],
     "@typescript-eslint/semi": ["error", "never"],
-    "@typescript-eslint/quotes": ["error", "double"],
+    "@typescript-eslint/quotes": [
+      "error",
+      "double",
+      {
+        avoidEscape: true,
+      },
+    ],
     // Add known-safe exceptions to no-param-reassign.
     "no-param-reassign": [
       airbnbNoParamReassignRules[0],


### PR DESCRIPTION
Set `avoidEscape: true` option which:
> allows strings to use single-quotes or double-quotes so long as the string contains a quote that would have to be escaped otherwise

This allows us to define strings like
```
property: "message with sample 'value' inside it"
```