### PR TITLE
Improve "getting started" instructions in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,10 @@ React / JSX.
 
 ## Getting started
 
-1. Install the shared config with `yarn`
+1. Install `eslint` and the shared config with `yarn`
 
 ```bash
+yarn add -D eslint prettier @typescript-eslint/eslint-plugin @typescript-eslint/parser
 yarn add -D @thesis-co/eslint-config
 ```
 


### PR DESCRIPTION
These steps were necessary to install the config for [`thesis/simulations`](https://github.com/thesis/simulations).