### PR TITLE
Backport linting rules used across Thesis projects

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,7 +28,11 @@ module.exports = {
     "plugin:@typescript-eslint/recommended",
   ],
   rules: {
+    // Executive decision: semi-colons aren't removed by prettier for backwards
+    // compatibility. We don't have that requirement 🔪
     semi: ["error", "never"],
+    // Executive decision: Don't use `backtick quotes` unless you're using
+    // interpolation, and prefer double quotes to single. Consistency is 🔑
     quotes: [
       "error",
       "double",
@@ -74,8 +78,10 @@ module.exports = {
         },
       },
     ],
+    // prefer the @typescript-eslint rule to the base
     "@typescript-eslint/no-unused-vars": "error",
     "no-unused-vars": "off",
+    // .only tests being committed are typically a mistake
     "no-only-tests/no-only-tests": "error",
     "prettier/prettier": [
       "error",

--- a/index.js
+++ b/index.js
@@ -1,5 +1,12 @@
-// This is a JS file, so this rule can't be followed.
+// This is a non-ESM JS file, so this rule can't be followed.
 /* eslint-disable @typescript-eslint/no-var-requires */
+const {
+  rules: {
+    "@typescript-eslint/naming-convention":
+      airbnbTypeScriptNamingConventionRules,
+  },
+} = require("eslint-config-airbnb-typescript/lib/shared")
+
 const {
   rules: { "no-param-reassign": airbnbNoParamReassignRules },
 } = require("eslint-config-airbnb-base/rules/best-practices")
@@ -51,6 +58,24 @@ module.exports = {
         ],
       },
     ],
+    "@typescript-eslint/naming-convention": [
+      ...airbnbTypeScriptNamingConventionRules,
+      // Allow underscore-only identifiers to indicate ignored positional variables.
+      {
+        selector: "variable",
+        format: null,
+        filter: {
+          regex: "^_+$",
+          match: true,
+        },
+        custom: {
+          regex: "^_+$",
+          match: true,
+        },
+      },
+    ],
+    "@typescript-eslint/no-unused-vars": "error",
+    "no-unused-vars": "off",
     "no-only-tests/no-only-tests": "error",
     "prettier/prettier": [
       "error",


### PR DESCRIPTION
In particular, we want to allow `_` as a throwaway position variable name, and we want to error on unused variables in Typescript.