### PR TITLE
Use typescript recommended-type-checked rules 

### DIFF
--- a/index.js
+++ b/index.js
@@ -92,4 +92,10 @@ module.exports = {
     "no-only-tests/no-only-tests": "error",
     "prettier/prettier": ["error", thesisPrettierConfig],
   },
+  overrides: [
+    {
+      files: ["*.js"],
+      extends: ["plugin:@typescript-eslint/disable-type-checked"],
+    },
+  ],
 }

--- a/index.js
+++ b/index.js
@@ -27,7 +27,7 @@ module.exports = {
     "prettier",
     "plugin:import/recommended",
     "plugin:import/typescript",
-    "plugin:@typescript-eslint/recommended",
+    "plugin:@typescript-eslint/recommended-type-checked",
   ],
   rules: {
     // Executive decision: semi-colons aren't removed by prettier for backwards

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@thesis-co/eslint-config",
-  "version": "0.7.0-pre",
+  "version": "0.8.0-pre",
   "description": "ESLint TypeScript shareable config for Thesis wide projects",
   "main": "index.js",
   "repository": "git@github.com:thesis/eslint-config.git",


### PR DESCRIPTION
We switch from [`@typescript-eslint/recommended`](https://typescript-eslint.io/linting/configs/#recommended) to [`@typescript-eslint/recommended-type-checked`](https://typescript-eslint.io/linting/configs/#recommended-type-checked).
The new configuration extends the previous one with additional rules related to type information.