### PR TITLE
Add rule to enforce whitespaces in multiline variables

### DIFF
--- a/index.js
+++ b/index.js
@@ -91,6 +91,20 @@ module.exports = {
     // .only tests being committed are typically a mistake
     "no-only-tests/no-only-tests": "error",
     "prettier/prettier": ["error", thesisPrettierConfig],
+    // Enforces whitespaces before and after multiline variables
+    "padding-line-between-statements": [
+      "error",
+      {
+        blankLine: "always",
+        prev: "*",
+        next: ["multiline-const", "multiline-let", "multiline-var"],
+      },
+      {
+        blankLine: "always",
+        prev: ["multiline-const", "multiline-let", "multiline-var"],
+        next: "*",
+      },
+    ],
   },
   overrides: [
     {


### PR DESCRIPTION
## What has been done

This PR introduces a rule that will enforce multline variables to have a whitespace before and after their declaration. The goal of this rule is to improve code readability by adding some breathing space to variables

### Before

```
const x = 0
const y = 1
const object = {
  a: 'some-value'
  b: 'some-value'
}
const z = 2
```

### After

```
const x = 0
const y = 1

const object = {
  a: 'some-value'
  b: 'some-value'
}

const z = 2
```